### PR TITLE
Monomorphic Expr

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "purescript-console": "^2.0.0",
-    "purescript-foreign-generic": "^2.0.0",
+    "purescript-foreign-generic": "^3.0.0",
     "purescript-errors": "^2.0.0",
     "purescript-strings": "^2.0.0",
     "purescript-newtype": "^1.0.0",

--- a/src/CoreFn/Expr.purs
+++ b/src/CoreFn/Expr.purs
@@ -13,7 +13,7 @@ module CoreFn.Expr
 import Prelude
 import Data.Foreign.Keys as K
 import CoreFn.Ident (Ident(..), readIdent)
-import CoreFn.Names (Qualified, readQualified)
+import CoreFn.Names (Qualified)
 import CoreFn.Util (objectProps)
 import Data.Either (Either(..), either)
 import Data.Foreign (F, Foreign, ForeignError(..), fail, parseJSON, readArray, readBoolean, readChar, readInt, readNumber, readString)
@@ -156,7 +156,7 @@ instance isForeignExpr :: IsForeign Expr where
       App <$> read expr1 <*> read expr2
     readExpr' "Var" y = do
       value <- readProp 1 y
-      Var <$> readQualified Ident value
+      Var <$> read value
     readExpr' label _ = fail $ ForeignError $ "Unknown expression: " <> label
 
 readExprJSON :: String -> F Expr

--- a/src/CoreFn/Expr.purs
+++ b/src/CoreFn/Expr.purs
@@ -15,7 +15,8 @@ import Data.Foreign.Keys as K
 import CoreFn.Ident (Ident(..), readIdent)
 import CoreFn.Names (Qualified)
 import CoreFn.Util (objectProps)
-import Data.Either (Either(..), either)
+import Data.Either (Either(..))
+import Data.Generic (class Generic, gShow)
 import Data.Foreign (F, Foreign, ForeignError(..), fail, parseJSON, readArray, readBoolean, readChar, readInt, readNumber, readString)
 import Data.Foreign.Class (class IsForeign, read, readProp)
 import Data.Foreign.Index (prop)
@@ -54,14 +55,10 @@ data Literal a
 
 derive instance eqLiteral :: Eq a => Eq (Literal a)
 derive instance ordLiteral :: Ord a => Ord (Literal a)
+derive instance genericLiteral :: Generic a => Generic (Literal a)
 
-instance showLiteral :: Show a => Show (Literal a) where
-  show (NumericLiteral e) = "(NumericLiteral " <> either show show e <> ")"
-  show (StringLiteral s) = "(StringLiteral " <> show s <> ")"
-  show (CharLiteral c) = "(CharLiteral " <> show c <> ")"
-  show (BooleanLiteral b) = "(BooleanLiteral " <> show b <> ")"
-  show (ArrayLiteral a) = "(ArrayLiteral " <> show a <> ")"
-  show (ObjectLiteral o) = "(ObjectLiteral" <> show o <> ")"
+instance showLiteral :: Generic a => Show (Literal a) where
+  show = gShow
 
 instance isForeignLiteral :: IsForeign a => IsForeign (Literal a) where
   read x = do
@@ -130,12 +127,10 @@ data Expr
 
 derive instance eqExpr :: Eq Expr
 derive instance ordExpr :: Ord Expr
+derive instance genericExpr :: Generic Expr
 
 instance showExpr :: Show Expr where
-  show (Literal x) = "(Literal " <> show x <> ")"
-  show (Abs x y) = "(Abs " <> show x <> " " <> show y <> ")"
-  show (App x y) = "(App " <> show x <> " " <> show y <> ")"
-  show (Var x) = "(Var " <> show x <> ")"
+  show = gShow
 
 instance isForeignExpr :: IsForeign Expr where
   read x = do

--- a/src/CoreFn/Ident.purs
+++ b/src/CoreFn/Ident.purs
@@ -10,21 +10,17 @@ module CoreFn.Ident
 import Prelude
 import Data.Foreign (F, Foreign, parseJSON, readString)
 import Data.Generic (gShow, class Generic)
-import Data.Maybe (Maybe)
+import Data.Newtype (class Newtype)
 
-data Ident
-  -- |
-  -- An alphanumeric identifier
-  --
-  = Ident String
-  -- |
-  -- A generated name for an identifier
-  --
-  | GenIdent (Maybe String) Int
+-- |
+-- An alphanumeric identifier
+--
+newtype Ident = Ident String
 
 derive instance eqIdent :: Eq Ident
 derive instance genericIdent :: Generic Ident
 derive instance ordIdent :: Ord Ident
+derive instance newtypeIdent :: Newtype Ident _
 
 instance showIdent :: Show Ident where
   show = gShow

--- a/src/CoreFn/Module.purs
+++ b/src/CoreFn/Module.purs
@@ -5,12 +5,12 @@ module CoreFn.Module
   ) where
 
 import Prelude
-import CoreFn.Expr (Bind, readBind)
+import CoreFn.Expr (Bind)
 import CoreFn.Ident (Ident, readIdent)
 import CoreFn.Names (ModuleName(..), readModuleName)
 import CoreFn.Util (objectProp)
 import Data.Foreign (F, Foreign, parseJSON, readArray, readString)
-import Data.Foreign.Class (readProp)
+import Data.Foreign.Class (read, readProp)
 import Data.Foreign.Index (class Index, prop)
 import Data.Traversable (traverse)
 
@@ -19,7 +19,7 @@ import Data.Traversable (traverse)
 --
 data Module a = Module
   { builtWith :: String
-  , moduleDecls :: Array (Bind a)
+  , moduleDecls :: Array Bind
   , moduleExports :: Array Ident
   , moduleForeign :: Array Ident
   , moduleImports :: Array ModuleName
@@ -49,7 +49,7 @@ readModule x = do
   o <- objectProp "Module name not found" x
 
   builtWith     <- prop "builtWith" o.value >>= readString
-  moduleDecls   <- traverseArrayProp "decls"   o.value readBind
+  moduleDecls   <- traverseArrayProp "decls"   o.value read
   moduleExports <- traverseArrayProp "exports" o.value readIdent
   moduleForeign <- traverseArrayProp "foreign" o.value readIdent
   moduleImports <- traverseArrayProp "imports" o.value readModuleName

--- a/test/CoreFn/Expr.purs
+++ b/test/CoreFn/Expr.purs
@@ -360,7 +360,7 @@ testBindings = do
       let var = Var qualified
       let literal = Literal (StringLiteral "Hello world!")
       let app = App var literal
-      let binding = Tuple (Tuple unit ident) app
+      let binding = Tuple ident app
       assertEqual x (Bind [binding])
 
   -- |
@@ -412,7 +412,7 @@ testBindings = do
       let fAppVar2 = Var (Qualified Nothing (Ident "x"))
       let fApp = App fAppVar1 fAppVar2
       let fAbs = Abs  (Ident "x") fApp
-      let fBinding = Tuple (Tuple unit fIdent) fAbs
+      let fBinding = Tuple fIdent fAbs
 
       let gIdent = Ident "g"
       let gModuleName = Just (ModuleName "Example")
@@ -421,6 +421,6 @@ testBindings = do
       let gAppVar2 = Var (Qualified Nothing (Ident "x"))
       let gApp = App gAppVar1 gAppVar2
       let gAbs = Abs (Ident "x") gApp
-      let gBinding = Tuple (Tuple unit gIdent) gAbs
+      let gBinding = Tuple gIdent gAbs
 
       assertEqual x (Bind [fBinding, gBinding])

--- a/test/CoreFn/Expr.purs
+++ b/test/CoreFn/Expr.purs
@@ -137,7 +137,7 @@ testLiterals = do
 
     expectSuccess description (readLiteralJSON json) \x ->
       assertEqual x $ ArrayLiteral
-        [ Literal unit (StringLiteral "Hello world!")
+        [ Literal (StringLiteral "Hello world!")
         ]
 
   -- |
@@ -163,7 +163,7 @@ testLiterals = do
 
     expectSuccess description (readLiteralJSON json) \x ->
       assertEqual x $ ObjectLiteral
-        [ Tuple "hello" (Literal unit (StringLiteral "world!"))
+        [ Tuple "hello" (Literal (StringLiteral "world!"))
         ]
 
   -- |
@@ -212,7 +212,7 @@ testExpr = do
     """
 
     expectSuccess description (readExprJSON json) \x ->
-      assertEqual x (Literal unit (StringLiteral "Hello world!"))
+      assertEqual x (Literal (StringLiteral "Hello world!"))
 
   -- |
   -- Abs
@@ -234,8 +234,8 @@ testExpr = do
     expectSuccess description (readExprJSON json) \x -> do
       let ident = Ident "x"
       let qualified = Qualified Nothing (Ident "x")
-      let var = Var unit qualified
-      assertEqual x (Abs unit ident var)
+      let var = Var qualified
+      assertEqual x (Abs ident var)
 
   -- |
   -- App
@@ -263,9 +263,9 @@ testExpr = do
     expectSuccess description (readExprJSON json) \x -> do
       let moduleName = Just (ModuleName "Control.Monad.Eff.Console")
       let qualified = Qualified moduleName (Ident "log")
-      let var = Var unit qualified
-      let literal = Literal unit (StringLiteral "Hello world!")
-      assertEqual x (App unit var literal)
+      let var = Var qualified
+      let literal = Literal (StringLiteral "Hello world!")
+      assertEqual x (App var literal)
 
   -- |
   -- Var
@@ -283,7 +283,7 @@ testExpr = do
     expectSuccess description (readExprJSON json) \x -> do
       let moduleName = Just (ModuleName "Control.Monad.Eff.Console")
       let qualified = Qualified moduleName (Ident "log")
-      assertEqual x (Var unit qualified)
+      assertEqual x (Var qualified)
 
   -- |
   -- Unknown
@@ -357,9 +357,9 @@ testBindings = do
       let ident = Ident "main"
       let moduleName = Just (ModuleName "Control.Monad.Eff.Console")
       let qualified = Qualified moduleName (Ident "log")
-      let var = Var unit qualified
-      let literal = Literal unit (StringLiteral "Hello world!")
-      let app = App unit var literal
+      let var = Var qualified
+      let literal = Literal (StringLiteral "Hello world!")
+      let app = App var literal
       let binding = Tuple (Tuple unit ident) app
       assertEqual x (Bind [binding])
 
@@ -408,19 +408,19 @@ testBindings = do
       let fIdent = Ident "f"
       let fModuleName = Just (ModuleName "Example")
       let fQualified = Qualified fModuleName (Ident "g")
-      let fAppVar1 = Var unit fQualified
-      let fAppVar2 = Var unit (Qualified Nothing (Ident "x"))
-      let fApp = App unit fAppVar1 fAppVar2
-      let fAbs = Abs unit (Ident "x") fApp
+      let fAppVar1 = Var fQualified
+      let fAppVar2 = Var (Qualified Nothing (Ident "x"))
+      let fApp = App fAppVar1 fAppVar2
+      let fAbs = Abs  (Ident "x") fApp
       let fBinding = Tuple (Tuple unit fIdent) fAbs
 
       let gIdent = Ident "g"
       let gModuleName = Just (ModuleName "Example")
       let gQualified = Qualified gModuleName (Ident "f")
-      let gAppVar1 = Var unit gQualified
-      let gAppVar2 = Var unit (Qualified Nothing (Ident "x"))
-      let gApp = App unit gAppVar1 gAppVar2
-      let gAbs = Abs unit (Ident "x") gApp
+      let gAppVar1 = Var gQualified
+      let gAppVar2 = Var (Qualified Nothing (Ident "x"))
+      let gApp = App gAppVar1 gAppVar2
+      let gAbs = Abs (Ident "x") gApp
       let gBinding = Tuple (Tuple unit gIdent) gAbs
 
       assertEqual x (Bind [fBinding, gBinding])

--- a/test/CoreFn/Module.purs
+++ b/test/CoreFn/Module.purs
@@ -176,12 +176,12 @@ testModule = do
     expectSuccess description (readModuleJSON json) \(Module x) -> do
       let xIdent = Ident "x"
       let xLiteral = Literal (StringLiteral "x")
-      let xBinding = Tuple (Tuple unit xIdent) xLiteral
+      let xBinding = Tuple xIdent xLiteral
       let xDecl = Bind [ xBinding ]
 
       let yIdent = Ident "y"
       let yLiteral = Literal (StringLiteral "y")
-      let yBinding = Tuple (Tuple unit yIdent) yLiteral
+      let yBinding = Tuple yIdent yLiteral
       let yDecl = Bind [ yBinding ]
 
       assertEqual x.moduleDecls [ xDecl, yDecl ]

--- a/test/CoreFn/Module.purs
+++ b/test/CoreFn/Module.purs
@@ -175,12 +175,12 @@ testModule = do
 
     expectSuccess description (readModuleJSON json) \(Module x) -> do
       let xIdent = Ident "x"
-      let xLiteral = Literal unit (StringLiteral "x")
+      let xLiteral = Literal (StringLiteral "x")
       let xBinding = Tuple (Tuple unit xIdent) xLiteral
       let xDecl = Bind [ xBinding ]
 
       let yIdent = Ident "y"
-      let yLiteral = Literal unit (StringLiteral "y")
+      let yLiteral = Literal (StringLiteral "y")
       let yBinding = Tuple (Tuple unit yIdent) yLiteral
       let yDecl = Bind [ yBinding ]
 

--- a/test/CoreFn/Names.purs
+++ b/test/CoreFn/Names.purs
@@ -77,7 +77,7 @@ testNames = do
       "log"
     """
 
-    expectSuccess description (readQualifiedJSON Ident json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (Ident "log")
 
@@ -88,7 +88,7 @@ testNames = do
       "Control.Monad.Console.Eff.log"
     """
 
-    expectSuccess description (readQualifiedJSON Ident json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Control.Monad.Console.Eff")
       assertEqual y (Ident "log")
 
@@ -99,7 +99,7 @@ testNames = do
       "bind"
     """
 
-    expectSuccess description (readQualifiedJSON OpName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (OpName "bind")
 
@@ -110,7 +110,7 @@ testNames = do
       "Control.Bind.bind"
     """
 
-    expectSuccess description (readQualifiedJSON OpName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Control.Bind")
       assertEqual y (OpName "bind")
 
@@ -121,7 +121,7 @@ testNames = do
       "Nothing"
     """
 
-    expectSuccess description (readQualifiedJSON ProperName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (ProperName "Nothing")
 
@@ -132,6 +132,6 @@ testNames = do
       "Data.Maybe.Nothing"
     """
 
-    expectSuccess description (readQualifiedJSON ProperName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Data.Maybe")
       assertEqual y (ProperName "Nothing")


### PR DESCRIPTION
This is nowhere near ready but thought I'd put it out there for comments. While adding support for Binders I noticed that it would make things simpler to make `Expr` monomorphic. We don't yet need the type param for type annotations and it makes it much easier to write `IsForeign` instances. In particular I was now able to write a `IsForeign` instance for `Literal` which **is** parameterised over either `Expr` or `Binder`.

Comments?