### PR TITLE
Port for purescript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,15 +7,17 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^2.0.0",
-    "purescript-foreign-generic": "^2.0.0",
-    "purescript-errors": "^2.0.0",
-    "purescript-strings": "^2.0.0",
-    "purescript-newtype": "^1.0.0",
-    "purescript-tuples": "^3.0.0",
-    "purescript-foldable-traversable": "^2.0.0"
+    "purescript-prelude": "^3.1.0",
+    "purescript-console": "^3.0.0",
+    "purescript-foreign-generic": "^4.2.0",
+    "purescript-errors": "^3.0.0",
+    "purescript-strings": "^3.3.0",
+    "purescript-newtype": "^2.0.0",
+    "purescript-tuples": "^4.1.0",
+    "purescript-foldable-traversable": "^3.4.0",
+    "purescript-generics": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^2.0.0"
+    "purescript-psci-support": "^3.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,15 +9,18 @@
   "dependencies": {
     "purescript-prelude": "^3.1.0",
     "purescript-console": "^3.0.0",
-    "purescript-foreign-generic": "^4.2.0",
-    "purescript-errors": "^3.0.0",
     "purescript-strings": "^3.3.0",
     "purescript-newtype": "^2.0.0",
     "purescript-tuples": "^4.1.0",
     "purescript-foldable-traversable": "^3.4.0",
-    "purescript-generics": "^4.0.0"
+    "purescript-generics": "^4.0.0",
+    "purescript-argonaut": "^3.0.0",
+    "purescript-argonaut-codecs": "^3.2.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^3.0.0",
+    "purescript-debug": "^3.0.0",
+    "purescript-eff": "^3.1.0",
+    "purescript-exceptions": "^3.1.0"
   }
 }

--- a/src/CoreFn/Ident.purs
+++ b/src/CoreFn/Ident.purs
@@ -8,7 +8,11 @@ module CoreFn.Ident
   ) where
 
 import Prelude
-import Data.Foreign (F, Foreign, parseJSON, readString)
+
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Either (Either)
 import Data.Generic (gShow, class Generic)
 import Data.Maybe (Maybe)
 
@@ -29,8 +33,11 @@ derive instance ordIdent :: Ord Ident
 instance showIdent :: Show Ident where
   show = gShow
 
-readIdent :: Foreign -> F Ident
-readIdent x = Ident <$> readString x
+instance decodeJsonIdent :: DecodeJson Ident where
+  decodeJson = readIdent
 
-readIdentJSON :: String -> F Ident
-readIdentJSON = parseJSON >=> readIdent
+readIdent :: Json -> Either String Ident
+readIdent x = Ident <$> decodeJson x
+
+readIdentJSON :: String -> Either String Ident
+readIdentJSON = jsonParser >=> readIdent

--- a/src/CoreFn/Util.purs
+++ b/src/CoreFn/Util.purs
@@ -4,34 +4,36 @@
 module CoreFn.Util
   ( objectProp
   , objectProps
+  , jsonIndex
   ) where
 
 import Prelude
-import Data.Foreign.Keys as K
-import Control.Error.Util (exceptNoteA)
-import Data.Array (head)
-import Data.Foreign (F, Foreign, ForeignError(ForeignError))
-import Data.Foreign.Index (prop)
-import Data.Identity (Identity(..))
-import Data.List.NonEmpty (singleton)
-import Data.Traversable (traverse)
 
-type Pair = { key :: String, value :: Foreign }
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Array (head)
+import Data.Array as Array
+import Data.Bifunctor (lmap)
+import Data.Either (Either, note)
+import Data.StrMap as StrMap
+import Data.Tuple (uncurry)
+import Data.Unfoldable (class Unfoldable)
+
+type Pair = { key :: String, value :: Json }
+
+-- | Construct a `Pair` from the provided values.
+pair :: String -> Json -> Pair
+pair key value =
+  { key, value }
 
 -- |
 -- Create an array of records by reading a JSON object.
 --
-objectProps :: Foreign -> F (Array Pair)
-objectProps x = do
-  keys <- K.keys x
-  traverse toPair keys
-
-  where
-
-  toPair :: String -> F Pair
-  toPair key = do
-    value <- prop key x
-    pure $ { key, value }
+objectProps
+  :: forall f. Functor f => Unfoldable f => Json -> Either String (f Pair)
+objectProps json = do
+  object <- decodeJson json
+  pure $ uncurry pair <$> StrMap.toUnfoldable object
 
 -- |
 -- Create a record by reading a JSON object.
@@ -41,7 +43,13 @@ objectProps x = do
 --
 -- The provided error message is used if a key cannot be obtained.
 --
-objectProp :: String -> Foreign -> F Pair
+objectProp :: String -> Json -> Either String Pair
 objectProp message x = do
   pairs <- objectProps x
-  exceptNoteA ((Identity <<< head) pairs) (singleton (ForeignError message))
+  note message $ head pairs
+
+jsonIndex :: forall a. DecodeJson a => Json -> Int -> Either String a
+jsonIndex json i = lmap (\err -> "[" <> show i <> "]" <> ": " <> err) do
+  array :: Array Json <- decodeJson json
+  value <- note "no value at index" $ Array.index array i
+  decodeJson value

--- a/test/CoreFn/Expr.purs
+++ b/test/CoreFn/Expr.purs
@@ -12,8 +12,6 @@ import CoreFn.Expr (Bind(..), Expr(..), Literal(..), readBindJSON, readExprJSON,
 import CoreFn.Ident (Ident(..))
 import CoreFn.Names (ModuleName(..), Qualified(..))
 import Data.Either (Either(..))
-import Data.Foreign (ForeignError(..))
-import Data.List.NonEmpty (singleton)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Test.Util (assertEqual, expectFailure, expectSuccess)
@@ -180,7 +178,7 @@ testLiterals = do
     """
 
     expectFailure description (readLiteralJSON json) \x ->
-      assertEqual x "Unknown literal: SomeLiteral"
+      assertEqual x "Literal: SomeLiteral: Unknown literal"
 
 testExpr :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testExpr = do
@@ -305,7 +303,7 @@ testExpr = do
     """
 
     expectFailure description (readExprJSON json) \x ->
-      assertEqual x "Unknown expression: SomeExpression"
+      assertEqual x "Expr: SomeExpression: Unknown expression"
 
 testBindings :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testBindings = do

--- a/test/CoreFn/Expr.purs
+++ b/test/CoreFn/Expr.purs
@@ -18,7 +18,7 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Test.Util (assertEqual, expectFailure, expectSuccess)
 
-testLiterals :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testLiterals :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testLiterals = do
   log ""
   log "Test Literals"
@@ -180,9 +180,9 @@ testLiterals = do
     """
 
     expectFailure description (readLiteralJSON json) \x ->
-      assertEqual x (singleton (ForeignError "Unknown literal: SomeLiteral"))
+      assertEqual x "Unknown literal: SomeLiteral"
 
-testExpr :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testExpr :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testExpr = do
   log ""
   log "Test Expr"
@@ -305,9 +305,9 @@ testExpr = do
     """
 
     expectFailure description (readExprJSON json) \x ->
-      assertEqual x (singleton (ForeignError "Unknown expression: SomeExpression"))
+      assertEqual x "Unknown expression: SomeExpression"
 
-testBindings :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testBindings :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testBindings = do
   log ""
   log "Test Bind"

--- a/test/CoreFn/Ident.purs
+++ b/test/CoreFn/Ident.purs
@@ -9,7 +9,7 @@ import Control.Monad.Eff.Exception (EXCEPTION)
 import CoreFn.Ident (Ident(..), readIdentJSON)
 import Test.Util (assertEqual, expectSuccess)
 
-testIdent :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testIdent :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testIdent = do
   log ""
   log "Test Ident"

--- a/test/CoreFn/Module.purs
+++ b/test/CoreFn/Module.purs
@@ -15,7 +15,7 @@ import Data.List.NonEmpty (singleton)
 import Data.Tuple (Tuple(..))
 import Test.Util (assertEqual, expectFailure, expectSuccess)
 
-testModule :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testModule :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testModule = do
   log ""
   log "Test Module"
@@ -41,7 +41,7 @@ testModule = do
     """
 
     expectFailure description (readModuleJSON json) \x ->
-      assertEqual x (singleton (ForeignError "Module name not found"))
+      assertEqual x "Module name not found"
 
   testName = do
     let description = "Module name from JSON results in success"

--- a/test/CoreFn/Module.purs
+++ b/test/CoreFn/Module.purs
@@ -10,8 +10,6 @@ import CoreFn.Expr (Bind(..), Expr(..), Literal(..))
 import CoreFn.Ident (Ident(..))
 import CoreFn.Module (Module(..), readModuleJSON)
 import CoreFn.Names (ModuleName(..))
-import Data.Foreign (ForeignError(..))
-import Data.List.NonEmpty (singleton)
 import Data.Tuple (Tuple(..))
 import Test.Util (assertEqual, expectFailure, expectSuccess)
 

--- a/test/CoreFn/Names.purs
+++ b/test/CoreFn/Names.purs
@@ -11,7 +11,7 @@ import CoreFn.Names (ModuleName(..), OpName(..), ProperName(..), Qualified(..), 
 import Data.Maybe (Maybe(..))
 import Test.Util (assertEqual, expectSuccess)
 
-testNames :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+testNames :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 testNames = do
   log ""
   log "Test Names"

--- a/test/CoreFn/Names.purs
+++ b/test/CoreFn/Names.purs
@@ -77,7 +77,7 @@ testNames = do
       "log"
     """
 
-    expectSuccess description (readQualifiedJSON Ident json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (Ident "log")
 
@@ -88,7 +88,7 @@ testNames = do
       "Control.Monad.Console.Eff.log"
     """
 
-    expectSuccess description (readQualifiedJSON Ident json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Control.Monad.Console.Eff")
       assertEqual y (Ident "log")
 
@@ -99,7 +99,7 @@ testNames = do
       "bind"
     """
 
-    expectSuccess description (readQualifiedJSON OpName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (OpName "bind")
 
@@ -110,7 +110,7 @@ testNames = do
       "Control.Bind.bind"
     """
 
-    expectSuccess description (readQualifiedJSON OpName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Control.Bind")
       assertEqual y (OpName "bind")
 
@@ -121,7 +121,7 @@ testNames = do
       "Nothing"
     """
 
-    expectSuccess description (readQualifiedJSON ProperName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x Nothing
       assertEqual y (ProperName "Nothing")
 
@@ -132,6 +132,6 @@ testNames = do
       "Data.Maybe.Nothing"
     """
 
-    expectSuccess description (readQualifiedJSON ProperName json) \(Qualified x y) -> do
+    expectSuccess description (readQualifiedJSON json) \(Qualified x y) -> do
       assertEqual x (Just $ ModuleName "Data.Maybe")
       assertEqual y (ProperName "Nothing")

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,7 +9,7 @@ import Test.CoreFn.Ident (testIdent)
 import Test.CoreFn.Module (testModule)
 import Test.CoreFn.Names (testNames)
 
-main :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+main :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
 main = do
   testIdent
   testNames

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -7,11 +7,8 @@ module Test.Util
 import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (log, CONSOLE)
-import Control.Monad.Eff.Exception (EXCEPTION, throwException, error)
-import Control.Monad.Except (runExcept)
+import Control.Monad.Eff.Exception (EXCEPTION, error, throwException)
 import Data.Either (either, Either)
-import Data.Foreign (F, ForeignError)
-import Data.List.Types (NonEmptyList)
 
 assertEqual
   :: forall a eff
@@ -63,7 +60,7 @@ expectFailure
   :: forall a eff
    . Show a
   => String
-  -> F a
+  -> Either String a
   -> (String -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
   -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 expectFailure description = expectLeft description
@@ -71,10 +68,10 @@ expectFailure description = expectLeft description
 expectSuccess
   :: forall a eff
    . String
-  -> F a
-expectSuccess description x = expectRight description (runExcept x)
+  -> Either String a
   -> (a -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
   -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
+expectSuccess description = expectRight description
 
 green :: String
 green = "\x1b[32m"

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -15,7 +15,7 @@ import Data.List.Types (NonEmptyList)
 
 assertEqual
   :: forall a eff
-   . (Eq a, Show a)
+   . Eq a => Show a
   => a
   -> a
   -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -18,23 +18,23 @@ assertEqual
    . (Eq a, Show a)
   => a
   -> a
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 assertEqual actual expected =
   if actual == expected
     then logSuccessShow actual
     else fail (show expected) (show actual)
 
-fail :: forall eff. String -> String -> Eff (err :: EXCEPTION | eff) Unit
+fail :: forall eff. String -> String -> Eff (exception :: EXCEPTION | eff) Unit
 fail expected actual = failure $ "\n"
   <> "  expected:\n"
   <> "    " <> expected <> "\n"
   <> "  actual:\n"
   <> "    " <> actual <> "\n"
 
-expectedLeft :: forall a eff. Show a => a -> Eff (err :: EXCEPTION | eff) Unit
+expectedLeft :: forall a eff. Show a => a -> Eff (exception :: EXCEPTION | eff) Unit
 expectedLeft x = fail "Left" $ show x
 
-expectedRight :: forall b eff. Show b => b -> Eff (err :: EXCEPTION | eff) Unit
+expectedRight :: forall b eff. Show b => b -> Eff (exception :: EXCEPTION | eff) Unit
 expectedRight x = fail "Right" $ show x
 
 expectLeft
@@ -42,8 +42,8 @@ expectLeft
    . Show b
   => String
   -> Either a b
-  -> (a -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit)
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
+  -> (a -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 expectLeft description x f = do
   log $ "  " <> description
   either f expectedLeft x
@@ -53,8 +53,8 @@ expectRight
    . Show a
   => String
   -> Either a b
-  -> (b -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit)
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
+  -> (b -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 expectRight description x g = do
   log $ "  " <> description
   either expectedRight g x
@@ -64,17 +64,17 @@ expectFailure
    . Show a
   => String
   -> F a
-  -> (NonEmptyList ForeignError -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit)
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
-expectFailure description x = expectLeft description (runExcept x)
+  -> (String -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
+expectFailure description = expectLeft description
 
 expectSuccess
   :: forall a eff
    . String
   -> F a
-  -> (a -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit)
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
 expectSuccess description x = expectRight description (runExcept x)
+  -> (a -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit)
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 
 green :: String
 green = "\x1b[32m"
@@ -95,8 +95,8 @@ logSuccessShow
   :: forall a eff
    . Show a
   => a
-  -> Eff (console :: CONSOLE, err :: EXCEPTION | eff) Unit
+  -> Eff (console :: CONSOLE, exception :: EXCEPTION | eff) Unit
 logSuccessShow x = logSuccess $ show x
 
-failure :: forall eff. String -> Eff (err :: EXCEPTION | eff) Unit
+failure :: forall eff. String -> Eff (exception :: EXCEPTION | eff) Unit
 failure = throwException <<< error


### PR DESCRIPTION
Updates needed to make it compile, work and pass the tests with 0.11 branch of compiler.

> **Note:** this doesn't involve the changes needed to support corefn AST *outputted by* 0.11, that would be the next step.

`purescript-foreign` have now removed all the json-related functionality for good, so the biggest change is the switch to `purescript-argonaut`.

- instead of concrete json-decoding functions (e.g. `readString`, `readInt`, `readIdent`, `readExpr`) polymorphic `decodeJson` is used in many places now.
	- to retain the explicitness types are specified when the result of `decodeJson` is binded in the `do`-notation
- errors are now communicated through `Either String`
  - typed error representation might be a subject of another commit
	- `lmap` is used to annotate error messages that come from parsers allowing to 'trace' a path at which the failure occured.