### PR TITLE
Test parsing all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - yarn global add purescript pulp bower purescript-psa
   - bower install
 script:
-  - pulp build -- --dump-corefn
+  - pulp build --include test -- --dump-corefn
   - pulp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ install:
   - yarn global add purescript pulp bower purescript-psa
   - bower install
 script:
+  - pulp build -- --dump-corefn
   - pulp test

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "purescript-generics": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^3.0.0",
+    "purescript-node-fs": "^4.0.1"
   }
 }

--- a/src/CoreFn/Expr.purs
+++ b/src/CoreFn/Expr.purs
@@ -288,8 +288,8 @@ readCaseAlternative x = do
 
   readGuardedExpr :: Foreign -> F (Tuple (Expr Unit) (Expr Unit))
   readGuardedExpr y = do
-    guard <- index y 1
-    expr <- index y 2
+    guard <- index y 0
+    expr <- index y 1
     Tuple <$> readExpr guard <*> readExpr expr
 
 readCaseAlternativeJSON :: String -> F (CaseAlternative Unit)

--- a/test/CoreFn/Expr.purs
+++ b/test/CoreFn/Expr.purs
@@ -601,6 +601,7 @@ testCaseAlternatives = do
   log "Test CaseAlternative"
 
   testCaseAlternative
+  testCaseAlternativeWithGuards
 
   where
 
@@ -639,6 +640,61 @@ testCaseAlternatives = do
       let binder = VarBinder unit (Ident "a")
       let binders = [ConstructorBinder unit type' constructor [binder]]
       let result = Right (Var unit (Qualified Nothing (Ident "a")))
+
+      assertEqual x (CaseAlternative {binders, result})
+
+  -- |
+  -- CaseAlternativeWithGuards
+  --
+  testCaseAlternativeWithGuards = do
+    let description = "CaseAlternativeWithGuards from JSON result in success"
+
+    let json = """
+      [
+        [
+          [
+            "VarBinder",
+            "x"
+          ]
+        ],
+        [
+          [
+            [
+              "Literal",
+              [
+                "BooleanLiteral",
+                false
+              ]
+            ],
+            [
+              "Var",
+              "y"
+            ]
+          ],
+          [
+            [
+              "Literal",
+              [
+                "BooleanLiteral",
+                true
+              ]
+            ],
+            [
+              "Var",
+              "x"
+            ]
+          ]
+        ]
+      ]
+    """
+
+    expectSuccess description (readCaseAlternativeJSON json) \x -> do
+      let binders = [VarBinder unit (Ident "x")]
+      let falseGuard = Literal unit (BooleanLiteral false)
+      let trueGuard = Literal unit (BooleanLiteral true)
+      let guard1 = Tuple falseGuard (Var unit (Qualified Nothing (Ident "y")))
+      let guard2 = Tuple trueGuard (Var unit (Qualified Nothing (Ident "x")))
+      let result = Left [guard1, guard2]
 
       assertEqual x (CaseAlternative {binders, result})
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,12 +5,14 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (log, CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
+import Node.FS (FS)
 import Test.CoreFn.Expr (testBinders, testBindings, testCaseAlternatives, testExpr, testLiterals)
 import Test.CoreFn.Ident (testIdent)
 import Test.CoreFn.Module (testModule)
 import Test.CoreFn.Names (testNames)
+import Test.Parsing (testParsing)
 
-main :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION | e) Unit
+main :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION, fs :: FS | e) Unit
 main = do
   testIdent
   testNames
@@ -20,4 +22,5 @@ main = do
   testCaseAlternatives
   testBinders
   testModule
+  testParsing
   log ""

--- a/test/Parsing.purs
+++ b/test/Parsing.purs
@@ -1,0 +1,29 @@
+module Test.Parsing where
+
+import Prelude
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (log, CONSOLE)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import CoreFn.Module (Module(..), readModuleJSON)
+import CoreFn.Names (ModuleName(..))
+import Data.Foldable (for_)
+import Node.Encoding (Encoding(..))
+import Node.FS (FS)
+import Node.FS.Sync (readTextFile, readdir)
+import Node.Path (concat)
+import Test.Util (assertEqual, expectSuccess)
+
+testParsing :: forall e. Eff (console :: CONSOLE, exception :: EXCEPTION, fs :: FS | e) Unit
+testParsing = do
+  log ""
+  log "Test parsing modules"
+
+  files <- readdir "output"
+  for_ files \file -> do
+    let description = "Parsing " <> file <> " results in success"
+
+    json <- readTextFile UTF8 (concat ["output", file, "corefn.json"])
+
+    expectSuccess description (readModuleJSON json) \(Module {moduleName}) ->
+      assertEqual moduleName (ModuleName file)


### PR DESCRIPTION
As mentioned in #45, we can try to parse every module we use (and the ones we're writing) as a real-world test case. It's surprisingly quick (not much difference in CI speed from before). It ended up finding a bug in case alternatives.

I just kind of threw this module together. Let me know if you'd like anything done differently.