### PR TITLE
Fix Show instances

### DIFF
--- a/src/CoreFn/Names.purs
+++ b/src/CoreFn/Names.purs
@@ -33,7 +33,7 @@ derive instance newtypeOpName :: Newtype OpName _
 derive instance ordOpName :: Ord OpName
 
 instance showOpName :: Show OpName where
-  show x = "(OpName " <> unwrap x <> ")"
+  show x = "(OpName " <> show (unwrap x) <> ")"
 
 
 -- |
@@ -47,7 +47,7 @@ derive instance newtypeProperName :: Newtype ProperName _
 derive instance ordProperName :: Ord ProperName
 
 instance showProperName :: Show ProperName where
-  show x = "(ProperName " <> unwrap x <> ")"
+  show x = "(ProperName " <> show (unwrap x) <> ")"
 
 
 -- |


### PR DESCRIPTION
Produces `ProperName "Main"` instead of `ProperName Main`, etc