### PR TITLE
Fix spacing of records in Show instances

### DIFF
--- a/src/CoreFn/Ann.purs
+++ b/src/CoreFn/Ann.purs
@@ -28,7 +28,7 @@ instance showAnn :: Show Ann where
       "{ sourceSpan: " <> show ann.sourceSpan <>
       ", comments: " <> show ann.comments <>
       ", type: " <> show ann.type <>
-      ", meta: " <> show ann.meta <>
+      ", meta: " <> show ann.meta <> " " <>
       "}" <>
     ")"
 
@@ -80,7 +80,7 @@ instance showSourcePos :: Show SourcePos where
  show (SourcePos { sourcePosLine, sourcePosColumn }) =
    "(SourcePos " <>
      "{ sourcePosLine: " <> show sourcePosLine <>
-     ", sourcePosColumn: " <> show sourcePosColumn <>
+     ", sourcePosColumn: " <> show sourcePosColumn <> " " <>
      "}" <>
    ")"
 
@@ -102,7 +102,7 @@ instance showSourceSpan :: Show SourceSpan where
     "(SourceSpan " <>
       "{ spanName: " <> show spanName <>
       ", spanStart: " <> show spanStart <>
-      ", spanEnd: " <> show spanEnd <>
+      ", spanEnd: " <> show spanEnd <> " "
       "}" <>
     ")"
 
@@ -254,7 +254,7 @@ instance showConstraint :: Show Constraint where
     "(Constraint " <>
       "{ constraintClass: " <> show constraintClass <>
       ", constraintArgs: " <> show constraintArgs <>
-      ", constraintData: " <> show constraintData <>
+      ", constraintData: " <> show constraintData <> " " <>
       "}" <>
     ")"
 

--- a/src/CoreFn/Expr.purs
+++ b/src/CoreFn/Expr.purs
@@ -158,6 +158,6 @@ instance showCaseAlternative :: Show a => Show (CaseAlternative a) where
   show (CaseAlternative { caseAlternativeBinders, caseAlternativeResult }) =
     "(CaseAlternative " <>
       "{ caseAlternativeBinders: " <> show caseAlternativeBinders <>
-      ", caseAlternativeResult: " <> show caseAlternativeResult <>
+      ", caseAlternativeResult: " <> show caseAlternativeResult <> " " <>
       "}" <>
     ")"

--- a/src/CoreFn/Module.purs
+++ b/src/CoreFn/Module.purs
@@ -39,7 +39,7 @@ instance showModule :: Show a => Show (Module a) where
       ", moduleImports: " <> show m.moduleImports <>
       ", moduleExports: " <> show m.moduleExports <>
       ", moduleForeign: " <> show m.moduleForeign <>
-      ", moduleDecls: " <> show m.moduleDecls <>
+      ", moduleDecls: " <> show m.moduleDecls <> " " <>
       "}" <>
     ")"
 
@@ -57,7 +57,7 @@ instance showModuleImport :: Show ModuleImport where
   show (ModuleImport moduleImport) =
     "(ModuleImport " <>
       "{ ann: " <> show moduleImport.ann <>
-      ", moduleName: " <> show moduleImport.moduleName <>
+      ", moduleName: " <> show moduleImport.moduleName <> " " <>
       "}" <>
     ")"
 


### PR DESCRIPTION
e.g. `{ "a": 1 }` instead of `{ "a": 1}`