### PR TITLE
Fix parsing of strings

### DIFF
--- a/test/CoreFn/FromJSON.purs
+++ b/test/CoreFn/FromJSON.purs
@@ -68,6 +68,12 @@ spec = describe "FromJSON" do
       """
       isRight m `shouldEqual` true
 
+    it "should parse complex strings" do
+      let m = runExcept $ moduleFromJSON """
+        {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x1","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"StringLiteral","value": [97,56320,55296,55296,55322,56325,55322,56838,122]},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
+      """
+      isRight m `shouldEqual` true
+
     it "should parse Constructor" do
       let m = runExcept $ moduleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"constructor","expression":{"constructorName":"Left","annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"typeName":"Either","fieldNames":["value0"],"type":"Constructor"},"bindType":"NonRec"}],"comments":[],"foreign":[]}


### PR DESCRIPTION
This fixes the case where the PS parser has parsed a string with lone
surrogates in which case the JSON contains an array of char codes
instead of a plain string.

Fixes #57 