### PR TITLE
Fully generalization Module Ann to Module a

### DIFF
--- a/src/CoreFn/Annotation.purs
+++ b/src/CoreFn/Annotation.purs
@@ -1,0 +1,59 @@
+module CoreFn.Annotation where
+
+import Prelude
+
+import CoreFn.Ann (Ann(..), SourcePos(..), SourceSpan(..))
+import CoreFn.Common (identFromJSON, object)
+import CoreFn.Meta (ConstructorType(..), Meta(..))
+import CoreFn.Module (FilePath)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
+import Data.Traversable (traverse)
+import Foreign (F, Foreign, ForeignError(..), fail, readArray, readInt, readNull, readString)
+import Foreign.Index (index, readProp)
+
+class Annotation a where
+  annFromJSON :: FilePath -> Foreign -> F a
+
+instance annotationAnn :: Annotation Ann where
+  annFromJSON modulePath = object \json -> do
+    sourceSpan <- readProp "sourceSpan" json >>= sourceSpanFromJSON
+    meta <- readProp "meta" json >>= readNull >>= traverse metaFromJSON
+    pure $ Ann { sourceSpan, comments: [], type: Nothing, meta }
+    where
+    sourceSpanFromJSON :: Foreign -> F SourceSpan
+    sourceSpanFromJSON = object \json -> do
+      spanStart <- readProp "start" json >>= sourcePosFromJSON
+      spanEnd <- readProp "end" json >>= sourcePosFromJSON
+      pure $ SourceSpan { spanName: unwrap modulePath, spanStart, spanEnd }
+
+    sourcePosFromJSON :: Foreign -> F SourcePos
+    sourcePosFromJSON json = do
+      sourcePosLine <- index json 0 >>= readInt
+      sourcePosColumn <- index json 1 >>= readInt
+      pure $ SourcePos { sourcePosLine, sourcePosColumn }
+
+    metaFromJSON :: Foreign -> F Meta
+    metaFromJSON = object $ \json -> do
+      type_ <- readProp "metaType" json >>= readString
+      case type_ of
+        "IsConstructor" -> isConstructorFromJSON json
+        "IsNewtype" -> pure IsNewtype
+        "IsTypeClassConstructor" -> pure IsTypeClassConstructor
+        "IsForeign" -> pure IsForeign
+        "IsWhere" -> pure IsWhere
+        _ -> fail $ ForeignError $ "Unknown Meta type :" <> type_
+      where
+      isConstructorFromJSON :: Foreign -> F Meta
+      isConstructorFromJSON json = do
+        ct <- readProp "constructorType" json >>= constructorTypeFromJSON
+        is <- readProp "identifiers" json >>= readArray >>= traverse identFromJSON
+        pure $ IsConstructor ct is
+
+    constructorTypeFromJSON :: Foreign -> F ConstructorType
+    constructorTypeFromJSON json = do
+      type_ <- readString json
+      case type_ of
+        "ProductType" -> pure ProductType
+        "SumType" -> pure SumType
+        _ -> fail $ ForeignError $ "Unknown ConstructorType: " <> type_

--- a/src/CoreFn/Common.purs
+++ b/src/CoreFn/Common.purs
@@ -1,0 +1,17 @@
+module CoreFn.Common where
+
+import Prelude
+
+import CoreFn.Ident (Ident(..))
+import Foreign (F, Foreign, ForeignError(..), fail, readString, typeOf)
+
+objectType :: String
+objectType = "object"
+
+object :: forall a. (Foreign -> F a) -> Foreign -> F a
+object _ json
+  | typ <- typeOf json, typ /= objectType = fail $ TypeMismatch objectType typ
+object f json = f json
+
+identFromJSON :: Foreign -> F Ident
+identFromJSON = map Ident <<< readString

--- a/src/CoreFn/Module.purs
+++ b/src/CoreFn/Module.purs
@@ -7,7 +7,7 @@ module CoreFn.Module
 
 import Prelude
 
-import CoreFn.Ann (Comment, Ann)
+import CoreFn.Ann (Comment)
 import CoreFn.Expr (Bind)
 import CoreFn.Ident (Ident)
 import CoreFn.Names (ModuleName)
@@ -20,7 +20,7 @@ newtype Module a = Module
   { moduleComments :: Array Comment
   , moduleName :: ModuleName
   , modulePath :: FilePath
-  , moduleImports :: Array ModuleImport
+  , moduleImports :: Array (ModuleImport a)
   , moduleExports :: Array Ident
   , moduleForeign :: Array Ident
   , moduleDecls :: Array (Bind a)
@@ -44,16 +44,16 @@ instance showModule :: Show a => Show (Module a) where
     ")"
 
 
-newtype ModuleImport = ModuleImport
-  { ann :: Ann
+newtype ModuleImport a = ModuleImport
+  { ann :: a
   , moduleName :: ModuleName
   }
 
-derive instance newtypeModuleImport :: Newtype ModuleImport _
-derive instance eqModuleImport :: Eq ModuleImport
-derive instance ordModuleImport :: Ord ModuleImport
+derive instance newtypeModuleImport :: Newtype (ModuleImport a) _
+derive instance eqModuleImport :: Eq a => Eq (ModuleImport a)
+derive instance ordModuleImport :: Ord a => Ord (ModuleImport a)
 
-instance showModuleImport :: Show ModuleImport where
+instance showModuleImport :: Show a => Show (ModuleImport a) where
   show (ModuleImport moduleImport) =
     "(ModuleImport " <>
       "{ ann: " <> show moduleImport.ann <>

--- a/test/CoreFn/FromJSON.purs
+++ b/test/CoreFn/FromJSON.purs
@@ -3,14 +3,15 @@ module Test.CoreFn.FromJSON where
 import Prelude
 
 import Control.Monad.Except (runExcept)
-import CoreFn.Ann (SourcePos(..), SourceSpan(..), ssAnn)
+import CoreFn.Ann (Ann, SourcePos(..), SourceSpan(..), ssAnn)
 import CoreFn.FromJSON (moduleFromJSON)
 import CoreFn.Ident (Ident(..))
-import CoreFn.Module (FilePath(..), ModuleImport(..))
+import CoreFn.Module (FilePath(..), Module, ModuleImport(..), Version)
 import CoreFn.Names (ModuleName(..), ProperName(..))
 import Data.Either (isRight)
 import Data.Newtype (unwrap)
 import Data.Traversable (traverse_)
+import Foreign (F)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
@@ -25,37 +26,38 @@ spec = describe "FromJSON" do
       , spanEnd: SourcePos { sourcePosLine: 0, sourcePosColumn: 0 }
       }
     ann = ssAnn ss
+    annModuleFromJSON = moduleFromJSON :: String -> F { version :: Version, module :: Module Ann }
 
   it "should parse an empty module" do
-    let m = runExcept $ moduleFromJSON """
+    let m = runExcept $ annModuleFromJSON """
       {"moduleName":["Example","Main"],"imports":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"moduleName":["Example","Main"]}],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[],"foreign":[]}
     """
     isRight m `shouldEqual` true
     traverse_ (_.module >>> unwrap >>> _.moduleName >>> shouldEqual mn) m
 
   it "should parse module path" do
-    let m = runExcept $ moduleFromJSON """
+    let m = runExcept $ annModuleFromJSON """
       {"moduleName":["Example","Main"],"imports":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"moduleName":["Example","Main"]}],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[],"foreign":[]}
     """
     isRight m `shouldEqual` true
     traverse_ (_.module >>> unwrap >>> _.modulePath >>> shouldEqual mp) m
 
   it "should parse imports" do
-    let m = runExcept $ moduleFromJSON """
+    let m = runExcept $ annModuleFromJSON """
       {"moduleName":["Example","Main"],"imports":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"moduleName":["Example","Main"]}],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[],"foreign":[]}
     """
     isRight m `shouldEqual` true
     traverse_ (_.module >>> unwrap >>> _.moduleImports >>> shouldEqual [ ModuleImport { ann, moduleName: mn } ]) m
 
   it "should parse exports" do
-    let m = runExcept $ moduleFromJSON """
+    let m = runExcept $ annModuleFromJSON """
       {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":["exp"],"decls":[],"comments":[],"foreign":[]}
     """
     isRight m `shouldEqual` true
     traverse_ (_.module >>> unwrap >>> _.moduleExports >>> shouldEqual [ Ident "exp" ]) m
 
   it "should parse foreign" do
-    let m = runExcept $ moduleFromJSON """
+    let m = runExcept $ annModuleFromJSON """
       {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[],"foreign":["exp"]}
     """
     isRight m `shouldEqual` true
@@ -63,112 +65,112 @@ spec = describe "FromJSON" do
 
   describe "Expr" do
     it "should parse literals" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x1","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"IntLiteral","value":1},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x2","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"NumberLiteral","value":1},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x3","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"StringLiteral","value":"abc"},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x4","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"c"},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x5","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"BooleanLiteral","value":true},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x6","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"ArrayLiteral","value":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"}]},"type":"Literal"},"bindType":"NonRec"},{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x7","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"ObjectLiteral","value":[["a",{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"}]]},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Constructor" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"constructor","expression":{"constructorName":"Left","annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"typeName":"Either","fieldNames":["value0"],"type":"Constructor"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Accessor" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"ObjectLiteral","value":[["field",{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"IntLiteral","value":1},"type":"Literal"}]]},"type":"Literal"},"fieldName":"field","type":"Accessor"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse ObjectUpdate" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"objectUpdate","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"ObjectLiteral","value":[["field",{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"StringLiteral","value":"abc"},"type":"Literal"}]]},"type":"Literal"},"updates":[["field",{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"StringLiteral","value":"xyz"},"type":"Literal"}]],"type":"ObjectUpdate"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Abs" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"abs","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"body":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":["Example","Main"],"identifier":"x"},"type":"Var"},"argument":"x","type":"Abs"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse App" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"app","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"argument":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"c"},"type":"Literal"},"type":"App","abstraction":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"body":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"},"argument":"x","type":"Abs"}},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Case" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"caseExpressions":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}],"caseAlternatives":[{"binders":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"binderType":"NullBinder"}],"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"isGuarded":false}],"type":"Case"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Case with guards" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"caseExpressions":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}],"caseAlternatives":[{"binders":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"binderType":"NullBinder"}],"expressions":[{"guard":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"BooleanLiteral","value":true},"type":"Literal"},"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"}}],"isGuarded":true}],"type":"Case"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse Let" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"binds":[{"binds":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"a","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}}],"bindType":"Rec"}],"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"BooleanLiteral","value":true},"type":"Literal"},"type":"Let"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
   describe "Meta" do
     it "should parse IsConstructor" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":{"metaType":"IsConstructor","identifiers":["x"],"constructorType":"ProductType"},"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x","expression":{"annotation":{"meta":{"metaType":"IsConstructor","identifiers":[],"constructorType":"SumType"},"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse IsNewtype" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":{"metaType":"IsNewtype"},"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse IsTypeClassConstructor" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":{"metaType":"IsTypeClassConstructor"},"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse IsForeign" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":{"metaType":"IsForeign"},"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"x","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
   describe "Binders" do
     it "should parse LiteralBinder" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"caseExpressions":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}],"caseAlternatives":[{"binders":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"literal":{"literalType":"BooleanLiteral","value":true},"binderType":"LiteralBinder"}],"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"isGuarded":false}],"type":"Case"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse VarBinder" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"caseExpressions":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}],"caseAlternatives":[{"binders":[{"constructorName":{"moduleName":null,"identifier":"Left"},"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"typeName":{"moduleName":["Data","Either"],"identifier":"Either"},"binders":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"z","binderType":"VarBinder"}],"binderType":"ConstructorBinder"}],"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"isGuarded":false}],"type":"Case"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse NamedBinder" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"case","expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"caseExpressions":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"moduleName":null,"identifier":"x"},"type":"Var"}],"caseAlternatives":[{"binders":[{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"w","binder":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"w'","binder":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"identifier":"w''","binderType":"VarBinder"},"binderType":"NamedBinder"},"binderType":"NamedBinder"}],"expression":{"annotation":{"meta":null,"sourceSpan":{"start":[0,0],"end":[0,0]}},"value":{"literalType":"CharLiteral","value":"a"},"type":"Literal"},"isGuarded":false}],"type":"Case"},"bindType":"NonRec"}],"comments":[],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
   describe "Comments" do
     it "should parse LineComment" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[{"LineComment":"line"}],"foreign":[]}
       """
       isRight m `shouldEqual` true
 
     it "should parse BlockComment" do
-      let m = runExcept $ moduleFromJSON """
+      let m = runExcept $ annModuleFromJSON """
         {"moduleName":["Example","Main"],"imports":[],"builtWith":"0","modulePath":"src/Example/Main.purs","exports":[],"decls":[],"comments":[{"BlockComment":"block"}],"foreign":[]}
       """
       isRight m `shouldEqual` true


### PR DESCRIPTION
The title is as it is.
Please let me know so that I can fix any concerns.

## Motivation for this PR

When I tried to understand how CoreFn works, I thought it would be better to read without annotations.

By generalizing Ann, it became easier to read by applying VoidAnn, for example.

- [[WIP] my learning process commit at testself branch](https://github.com/opyapeus/purescript-corefn/commit/0bbbaefd5eb76abb05daedd307bad107f081374b)

And like this commit, it may be a good idea to write a test module in the test code itself.

P.S. Thanks for merging my previous PR!
